### PR TITLE
Us#279 - Limit Client permissions by routing and security rules

### DIFF
--- a/vue-firebase-app/firestore.rules
+++ b/vue-firebase-app/firestore.rules
@@ -2,7 +2,7 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
     match /Clients/{clientId} {
-        allow read: if request.auth != null && clientExists();
+        allow read: if request.auth != null;
         //  Only allow admins to write Clients
         allow create: if request.auth != null && reviewerIsAdmin();
         //  Allow updates and writes if admin OR this is the current client
@@ -10,10 +10,10 @@ service cloud.firestore {
     }
     //  Rules for accessing Invitations
     match /Invitations/{invitationId} {
-        //  Everyone can create invitations
-        allow write;
+        //  Everyone can create invitations and read invitations
+        allow read,write;
         //  Only admins can read, update, and delete invitations
-        allow read,update,delete: if request.auth != null && reviewerIsAdmin();
+        allow update,delete: if request.auth != null && reviewerIsAdmin();
     }
     //  Rules for accessing Organizations
     match /Organizations/{organizationId} {
@@ -31,6 +31,8 @@ service cloud.firestore {
     }
     //  Rules for accessing Reviewers
     match /Reviewers/{reviewerId} {
+        //  We allow reads from anyone who is signed in
+        allow read: if request.auth != null;
         //	Only allow write, delete, create, and update if admin OR same UID
         allow write,delete,create,update: if request.auth != null && (reviewerIsAdmin() || request.auth.uid == reviewerId);
     }

--- a/vue-firebase-app/src/components/InvitationPending.vue
+++ b/vue-firebase-app/src/components/InvitationPending.vue
@@ -15,16 +15,27 @@ import { mapGetters } from 'vuex'
 export default {
     computed: {
         ...mapGetters({
-            loading: 'userLoading',
-            userDoc: 'userDocument'
+            user: 'user'
         })
     },
     mounted() {
-        if (this.userDoc) this.$router.push('/Dashboard')
+        //  Route the user accordingly
+        this.routeUser()
+    },
+    methods: {
+        routeUser() {
+            if (this.user.isAdmin) {
+                this.$router.replace({ name: 'AdminDashboard' })
+            } else if (this.user.isReviewer) {
+                this.$router.replace({ name: 'ReviewerDashboard' })
+            } else if (this.user.isClient) {
+                this.$router.replace({ name: 'ClientDashboard' })
+            }
+        }
     },
     watch: {
-        userDoc(val) {
-            if (val) this.$router.push('/Dashboard')
+        user() {
+            this.routeUser()
         }
     }
 }

--- a/vue-firebase-app/src/components/Login.vue
+++ b/vue-firebase-app/src/components/Login.vue
@@ -52,7 +52,7 @@
 </template>
 
 <script>
-import firebase from 'firebase';
+import firebase from 'firebase'
 
 export default {
     data() {
@@ -67,24 +67,26 @@ export default {
     methods: {
         submit() {
             firebase
-            .auth()
-            .signInWithEmailAndPassword(this.form.email, this.form.password)
-            .then((userCredential) => {
-                this.$store.dispatch('fetchUser', userCredential.user).then(storeUser => {
-                    if(storeUser && storeUser.isAdmin === true) {
-                        this.$router.replace({ name: 'AdminDashboard' });
-                    } else if(storeUser && storeUser.isClient === true) {
-                        this.$router.replace({ name: 'ClientDashboard' });
-                    } else if(storeUser) {
-                        this.$router.replace({ name: 'ReviewerDashboard' });
-                    } else {
-                        this.$router.replace({ name: 'AccessDenied' });
-                    }
-                });           
-            })
-            .catch((err) => {
-                this.error = err.message
-            })
+                .auth()
+                .signInWithEmailAndPassword(this.form.email, this.form.password)
+                .then((userCredential) => {
+                    this.$store
+                        .dispatch('fetchUser', userCredential.user)
+                        .then((storeUser) => {
+                            if (storeUser && storeUser.isAdmin === true) {
+                                this.$router.replace({ name: 'AdminDashboard' })
+                            } else if (storeUser && storeUser.isClient === true) {
+                                this.$router.replace({ name: 'ClientDashboard' })
+                            } else if (storeUser && storeUser.isReviewer) {
+                                this.$router.replace({ name: 'ReviewerDashboard' })
+                            } else {
+                                this.$router.replace({ name: 'Pending' })
+                            }
+                        })
+                })
+                .catch((err) => {
+                    this.error = err.message
+                })
         }
     }
 }

--- a/vue-firebase-app/src/components/Navbar.vue
+++ b/vue-firebase-app/src/components/Navbar.vue
@@ -27,8 +27,9 @@
                                         :to="item.link" class="nav-link">
                                         {{ item.name }}
                                     </router-link>
-                                    <div v-else-if="item.display" class="nav-item">
-                                        {{ user.data.displayName }}
+                                    <div v-else-if="item.display && user.loggedIn"
+                                        class="nav-item">
+                                        {{ user.displayName }}
                                     </div>
                                     <a v-else-if="item.method" class="nav-link"
                                         @click.prevent="signOut">Sign Out</a>
@@ -55,50 +56,49 @@ import { mapGetters } from 'vuex'
 import firebase from 'firebase'
 export default {
     mounted() {
-        console.log('USER DOC', this.userDocument)
+        console.log('USER', this.user)
     },
     computed: {
         ...mapGetters({
             // map `this.user` to `this.$store.getters.user`
-            user: 'user',
-            userDocument: 'userDocument'
+            user: 'user'
         }),
         navLinks() {
             const links = [
                 {
                     link: '/manage-clients',
                     name: 'Manage Client',
-                    hidden: !this.userDocument
+                    hidden: !this.user.isAdmin
                 },
                 {
                     link: '/project-reviews',
                     name: 'Project Reviews',
-                    hidden: !this.userDocument
+                    hidden: !this.user.isAdmin
                 },
                 {
                     link: '/addreviewer',
                     name: 'Add Reviewer',
-                    hidden: !this.userDocument
+                    hidden: !this.user.isAdmin
                 },
                 {
                     link: '/modifyreviewer',
                     name: 'Modify Reviewers',
-                    hidden: !this.userDocument
+                    hidden: !this.user.isAdmin
                 },
                 {
                     link: '/managereviewers',
                     name: 'Manage Reviewers',
-                    hidden: !this.userDocument
+                    hidden: !this.user.isAdmin
                 },
                 {
                     link: '/reviews',
                     name: 'Reviews',
-                    hidden: !this.userDocument
+                    hidden: !this.user.isReviewer
                 },
                 {
                     link: '/currentprojects',
                     name: 'Current Projects',
-                    hidden: !this.userDocument
+                    hidden: !this.user.isAdmin
                 },
                 {
                     display: true
@@ -117,6 +117,15 @@ export default {
                 .auth()
                 .signOut()
                 .then(() => {
+                    this.$store.commit('SET_USER', {
+                        displayName: '',
+                        email: '',
+                        isClient: false,
+                        isReviewer: false,
+                        isAdmin: false,
+                        loggedIn: false
+                    })
+                    console.log('userasdf', this.user)
                     this.$router.push({ path: 'login' })
                 })
         }

--- a/vue-firebase-app/src/main.js
+++ b/vue-firebase-app/src/main.js
@@ -40,8 +40,10 @@ var unsubscribe = firebase.auth().onAuthStateChanged(user => {
         router.replace({ name: 'AdminDashboard' });
       } else if(storeUser && storeUser.isClient === true) {
         router.replace({ name: 'ClientDashboard' });
-      } else {
+      } else if(storeUser && storeUser.isReviewer === true) {
         router.replace({ name: 'ReviewerDashboard' });
+      } else {
+        router.replace({ name: 'Pending' })
       }
 
       unsubscribe();

--- a/vue-firebase-app/src/main.js
+++ b/vue-firebase-app/src/main.js
@@ -30,9 +30,9 @@ firebase.initializeApp({
     appId: "1:46311260060:web:1e381fb482afc30c955259"
 })
 
-if (location.hostname === "localhost") {
-  firebase.firestore().useEmulator("localhost", 8080);
-}
+// if (location.hostname === "localhost") {
+//   firebase.firestore().useEmulator("localhost", 8080);
+// }
 
 var unsubscribe = firebase.auth().onAuthStateChanged(user => {
     store.dispatch("fetchUser", user).then(storeUser => {

--- a/vue-firebase-app/src/router/index.js
+++ b/vue-firebase-app/src/router/index.js
@@ -199,16 +199,12 @@ router.beforeEach(async (to, from, next) => {
     next("Login");
   } else {
     if(to.name === "Default" && store.state.user.isAdmin === true) {      
-        console.log('here1')
       next("AdminDashboard");
     } else if(to.name === "Default" && store.state.user.isClient === true) {      
-        console.log('here2')
         next("ClientDashboard");
     } else if(to.name === "Default" && store.state.user.isReviewer === true) {      
-        console.log('here3')
         next("ReviewerDashboard");
     } else if (requiresAdmin && store.state.user.isAdmin !== true || requiresReviewer && store.state.user.isReviewer !== true) {
-        console.log('here4')
         next("AccessDenied");
     } else if (to.name === "Default" && store.state.user.isClient === false && store.state.user.isReviewer === false) {
       next('Pending');

--- a/vue-firebase-app/src/router/index.js
+++ b/vue-firebase-app/src/router/index.js
@@ -45,6 +45,11 @@ const routes = [
     component: AccessDenied
   },
   {
+    path: '/Pending',
+    name: 'Pending',
+    component: InvitationPending
+  },
+  {
     path: '/register',
     name: 'Register',
     component: Register
@@ -54,7 +59,8 @@ const routes = [
     name: 'AdminDashboard',
     component: AdminDashboard,
     meta: {
-      requiresAdmin: true
+        requiresAuth: true,
+        requiresAdmin: true
     }
   },
   {
@@ -62,23 +68,24 @@ const routes = [
     name: 'ClientDashboard',
     component: ClientDashboard,
     meta: {
-      requiresAuth: true
+      requiresAuth: true,
     }
   },
   {
     path: '/ReviewerDashboard',
     name: 'ReviewerDashboard',
     component: ReviewerDashboard,
-      path: '/pending',
-      name: 'InvitationPending',
-      component: InvitationPending
+    meta: {
+        requiresAuth: true,
+        requiresReviewer: true
+    }
   },
   {
     path: '/project-reviews',
     name: 'Project Reviews',
     component: ProjectReviews,
     meta: {
-      requiresAdmin: true
+      requiresAdmin: true,
     }
   },
   {
@@ -116,7 +123,8 @@ const routes = [
         { path: '/review', name: 'Review', component: Review, props: true }
     ],
     meta: {
-      requiresAuth: true
+      requiresAuth: true,
+      requiresReviewer: true
     }
   },
   {
@@ -185,20 +193,25 @@ const router = createRouter({
 router.beforeEach(async (to, from, next) => {
   const requiresAuth = to.matched.some(record => record.meta.requiresAuth);
   const requiresAdmin = to.matched.some(record => record.meta.requiresAdmin);
+  const requiresReviewer = to.matched.some(record => record.meta.requiresReviewer)
 
   if (requiresAuth && !store.state.user.loggedIn) {
     next("Login");
-  } else if (requiresAuth && store.getters.user.loggedIn && !store.getters.userDocument) {
-    next('Pending')
   } else {
     if(to.name === "Default" && store.state.user.isAdmin === true) {      
+        console.log('here1')
       next("AdminDashboard");
     } else if(to.name === "Default" && store.state.user.isClient === true) {      
-      next("ClientDashboard");
-    } else if(to.name === "Default") {      
-      next("ReviewerDashboard");
-    } else if (requiresAdmin && store.state.user.isAdmin !== true) {
-      next("AccessDenied");
+        console.log('here2')
+        next("ClientDashboard");
+    } else if(to.name === "Default" && store.state.user.isReviewer === true) {      
+        console.log('here3')
+        next("ReviewerDashboard");
+    } else if (requiresAdmin && store.state.user.isAdmin !== true || requiresReviewer && store.state.user.isReviewer !== true) {
+        console.log('here4')
+        next("AccessDenied");
+    } else if (to.name === "Default" && store.state.user.isClient === false && store.state.user.isReviewer === false) {
+      next('Pending');
     } else {
       next();
     }


### PR DESCRIPTION
This adds additional security rule changes and client permissions so each type of User is clearly defined with their permissions. Based on the permission, different items are available in the navbar, as well as the routes they have access to. Each type of permission also determines their default route of either a specific dashboard, or the invitation pending if the user is a pending user.

I have the Client user setup to only have access to the dashboard with the intention that the dashboard can become a place to view all Reviews matching the Client's assigned organization, but I can always change it moving forward to give them access to the Reviews page and just have that only display their Organization's Reviews.